### PR TITLE
Dockerfile changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,36 @@
-FROM node:12 AS builder
+
+# First Stage: to install and build dependences
+FROM node:12.18.4 AS builder
 
 WORKDIR /app
 
 COPY ./package*.json ./
 RUN npm install
 
-COPY src src
 COPY tsconfig*.json ./
+COPY src src
 
 RUN npm run build && \
     npm prune --production
 
 
-FROM node:12-slim
+# Second Stage: use lightweight alpine image and run as non-root
+FROM node:12.18.4-alpine3.12
 
-WORKDIR /app
+RUN mkdir -p /home/node/app && chown -R node:node /home/node/app
 
-ADD VERSION .
+WORKDIR /home/node/app
 
-COPY entrypoint.sh entrypoint.sh
+COPY --chown=node:node --from=builder /app/node_modules ./node_modules
+COPY --chown=node:node --from=builder /app/dist ./dist
+
+COPY --chown=node:node VERSION .
+COPY --chown=node:node entrypoint.sh entrypoint.sh
 RUN chmod +x entrypoint.sh
 
-COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/node_modules ./node_modules
+USER node
 
 EXPOSE 3500
 
-ENTRYPOINT ["/app/entrypoint.sh"]
-
+ENTRYPOINT ["/home/node/app/entrypoint.sh"]
 CMD ["run"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 if [ "$1" = "run" ]; then


### PR DESCRIPTION
- pin base image version
- switched to node alpine version for smaller image
- run image as non-root
- reordered to optimize use of Docker build cache

Closes https://github.com/kadaster-labs/sensrnet-ops/issues/11