### PR TITLE
Update service name, local docker image name

### DIFF
--- a/deployment/base/deployment.yaml
+++ b/deployment/base/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         - name: EVENT_STORE_PORT
           value: eventstore-tcp
         - name: MULTICHAIN_HOST
-          value: multichain-service
+          value: multichain-node-service
         - name: MULTICHAIN_USER
           valueFrom:
               secretKeyRef:

--- a/deployment/overlays/local/patch.yaml
+++ b/deployment/overlays/local/patch.yaml
@@ -7,6 +7,6 @@ spec:
     spec:
       containers:
       - name: sync-bridge
-        image: sensrnetregistry.azurecr.io/sensrnet/sync-bridge:latest
+        image: sensrnet-sync_sync-bridge:latest
         imagePullPolicy: Never
         resources: {}


### PR DESCRIPTION
- Update the service reference to use the updated multichain name
- Use the appropriate docker image when building locally
- Tested in combination with 'kube-namespaces-fixes' in the sensrnet-multichain repository